### PR TITLE
Fix access count #4

### DIFF
--- a/static/frontend_script_every_site.js
+++ b/static/frontend_script_every_site.js
@@ -65,13 +65,6 @@ document.addEventListener("DOMContentLoaded", function(event) {
     }
     get_fav_from_database();
 
-    function post_access_count() {
-        const request = new XMLHttpRequest();
-        request.open('POST', '/access-count');
-        connect_to_database_with_body(request, {});
-    }
-    post_access_count()
-
     function load_comments() {
         const request = new XMLHttpRequest();
         request.onload = function onload() {

--- a/static/frontend_script_index.js
+++ b/static/frontend_script_index.js
@@ -1,6 +1,6 @@
 const NAME_DICT = {
     "index": "Startseite",
-    "mitgliedstaaten": "Mitgliedsstaaten",
+    "mitgliedstaaten": "Mitgliedstaaten",
     "organe": "Organe der EU",
     "parteien": "Parteien",
     "quiz": "Quiz",

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,7 @@
           <a href="organe.html">Organe</a>
         </div>
         <div>
-          <a href="mitgliedsstaaten.html">Mitgliedsstaaten</a>
+          <a href="mitgliedstaaten.html">Mitgliedstaaten</a>
         </div>
         <div>
           <a href="parteien.html">Parteien</a>

--- a/static/mitgliedstaaten.html
+++ b/static/mitgliedstaaten.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" />
     <script src="frontend_script_every_site.js"></script>
-    <title>Mitgliedsstaaten der EU</title>
+    <title>Mitgliedstaaten der EU</title>
   </head>
   <body>
     <div class="gridcontainer">
@@ -21,7 +21,7 @@
           <a href="organe.html">Organe</a>
         </div>
         <div>
-          <a href="mitgliedsstaaten.html">Mitgliedsstaaten</a>
+          <a href="mitgliedstaaten.html">Mitgliedstaaten</a>
         </div>
         <div>
           <a href="parteien.html">Parteien</a>
@@ -34,7 +34,7 @@
         </div>
       </header>
       <div class="content">
-      <h1>Mitgliedsstaaten der EU</h1>
+      <h1>Mitgliedstaaten der EU</h1>
         Die Europäische Union umfasst insgesamt <b>27</b> Mitgliedsstaten. Die
         EU-Gründugsstaaten sind:
         <ul>
@@ -45,8 +45,8 @@
           <li>Italien</li>
           <li>Deutschland</li>
         </ul>
-        <h2 id="alle_staaten">Liste der Mitgliedsstaaten</h2>
-        <a>Die folgenede Tabelle enthällt alle Mitgliedsstaaten, ihre jeweilige
+        <h2 id="alle_staaten">Liste der Mitgliedstaaten</h2>
+        <a>Die folgenede Tabelle enthällt alle Mitgliedstaaten, ihre jeweilige
           Hauptstadt, sowie das Datum an welchem sie der EU beigetreten sind.</a>
         <br />
         <div class="standard_table_container">
@@ -196,7 +196,7 @@
           </table>
         </div>
         <h2 id="spezielle_staaten">Spezielle EU-Terretorien</h2>
-        <a>Für einige Terretorien in Übersee, welche zu EU-Mitgliedsstaatenn gehören,
+        <a>Für einige Terretorien in Übersee, welche zu EU-Mitgliedstaatenn gehören,
           wurden gesonderte Regelungen aufgrund ihrer Lage getroffen. Diese
           Teretorien gehören jedoch trotzdem zur EU.</a>
         <br />
@@ -280,7 +280,7 @@
       <div class="sidebar_container">
         <h3>Inhalt</h3>
         <ol>
-          <li><a href="#alle_staaten">Liste der Mitgliedsstaaten</a></li>
+          <li><a href="#alle_staaten">Liste der Mitgliedstaaten</a></li>
           <li><a href="#spezielle_staaten">Spezielle EU-Terretorien</a></li>
           <li><a href="#quellen">Quellen</a></li>
         </ol>

--- a/static/organe.html
+++ b/static/organe.html
@@ -21,7 +21,7 @@
           <a href="organe.html">Organe</a>
         </div>
         <div>
-          <a href="mitgliedsstaaten.html">Mitgliedsstaaten</a>
+          <a href="mitgliedstaaten.html">Mitgliedstaaten</a>
         </div>
         <div>
           <a href="parteien.html">Parteien</a>
@@ -38,7 +38,7 @@
           Die Organe der EU
         </h1>
         <p>
-          Die Mitgliedsstaaten haben in der EU einen Teil ihrer Hoheitsrechte an
+          Die Mitgliedstaaten haben in der EU einen Teil ihrer Hoheitsrechte an
           selbständige Institutionen delegiert, die die gemeinschaftlichen, die
           nationalen und die Bürgerinteressen vertreten. Insgesamt gibt es laut dem
           Vertrag über die Europäische Union (EUV) sieben Organe:

--- a/static/parteien.html
+++ b/static/parteien.html
@@ -20,7 +20,7 @@
         <a href="organe.html">Organe</a>
       </div>
       <div>
-        <a href="mitgliedsstaaten.html">Mitgliedsstaaten</a>
+        <a href="mitgliedstaaten.html">Mitgliedstaaten</a>
       </div>
       <div>
         <a href="parteien.html">Parteien</a>

--- a/static/quiz-solutions.html
+++ b/static/quiz-solutions.html
@@ -21,7 +21,7 @@
           <a href="organe.html">Organe</a>
         </div>
         <div>
-          <a href="mitgliedsstaaten.html">Mitgliedsstaaten</a>
+          <a href="mitgliedstaaten.html">Mitgliedstaaten</a>
         </div>
         <div>
           <a href="parteien.html">Parteien</a>
@@ -54,7 +54,7 @@
           </p>
           <p class="quiz-element-answer">
             <b>Wie viele Staaten sind im Januar 2021 teil der EU?</b><br />
-            Die EU hat insgesamt 27 Mitgliedsstaaten. (siehe
+            Die EU hat insgesamt 27 Mitgliedstaaten. (siehe
             <a href="https://europa.eu/european-union/about-eu/countries_de"
               >Europa.eu</a
             >)

--- a/static/quiz.html
+++ b/static/quiz.html
@@ -21,7 +21,7 @@
           <a href="organe.html">Organe</a>
         </div>
         <div>
-          <a href="mitgliedsstaaten.html">Mitgliedsstaaten</a>
+          <a href="mitgliedstaaten.html">Mitgliedstaaten</a>
         </div>
         <div>
           <a href="parteien.html">Parteien</a>


### PR DESCRIPTION
Fehler aus #4 behoben.
`access-count` erfolgt nun beim aufruf der Seite, nicht über eine API.
Einheitliche bennenung von ~~Mitglidsstaaten~~ zu Mitglidstaaten.

This closes #4 